### PR TITLE
[#162030635] change destination

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -1,0 +1,7 @@
+export FLASK_APP="run.py"
+export FLASK_ENV="testing"
+export FLASK_DEBUG=1
+export JWT_SECRET_KEY="THidasfaasecanli87wlylasdfyae03rqeh"
+export DATABASE_URL="dbname='sendit_db' user='postgres' password='' host='localhost' port='5432'"
+export DATABASE_TEST_URL="dbname='travis_ci_test' user='postgres' password='' host='localhost' port='5432'"
+export DATABASE_PRODUCTION_URL="dbname='send_test' user='postgres' password='' host='localhost' port='5432'"

--- a/app/api/v2/__init__.py
+++ b/app/api/v2/__init__.py
@@ -2,7 +2,7 @@ from flask import Blueprint
 from flask_restful import Api
 
 from app.api.v2.views.user_views import SignupView, LoginView
-from app.api.v2.views.parcel_views import ParcelCreate
+from app.api.v2.views.parcel_views import ParcelCreate, ParcelDestination
 
 version2 = Blueprint("v2", __name__, url_prefix="/api/v2")
 api2 = Api(version2, catch_all_404s=True)
@@ -11,3 +11,4 @@ api2 = Api(version2, catch_all_404s=True)
 api2.add_resource(SignupView, "/auth/signup")
 api2.add_resource(LoginView, "/auth/login")
 api2.add_resource(ParcelCreate, "/users/parcels")
+api2.add_resource(ParcelDestination, "/parcels/<int:parcel_id>/destination")

--- a/app/api/v2/models/parcel_models.py
+++ b/app/api/v2/models/parcel_models.py
@@ -58,3 +58,51 @@ class Parcels():
             self.db.commit()
             print("Successfully saved the order to database")
             return 201
+
+    def change_destination(self, parcel_id, destination):
+        """This method will handle requests to the database to change the destination
+        of a parcel delivery order."""
+
+        user_data = get_jwt_identity()
+        parcel = self.get_parcel_by_id(parcel_id)
+        if not parcel:
+            return 404
+        elif parcel[2] != user_data["email"]:
+            return 401
+        elif parcel[9] != "pending":
+            return 400
+        else:
+            update_destination = """UPDATE parcels SET destination = '{}'
+            WHERE parcel_id = {}""".format(destination, parcel_id)
+        try:
+            cursor = self.db.cursor()
+            print("Successfully created cursor. Updating destination for parcel number {} ...".format(
+                parcel_id))
+            cursor.execute(update_destination)
+            self.db.commit()
+            count = cursor.rowcount
+            print("Destination successfully changed for parcel {}. {} rows affected".format(
+                parcel_id, count))
+            return 204
+        except (Exception, psycopg2.Error) as error:
+            print("Error. Could not update destination of parcel: ", error)
+            return error
+
+    def get_parcel_by_id(self, parcel_id):
+        """We have to validate a parcel exists before we can begin to make
+        changes on it."""
+
+        get_parcel = """SELECT * FROM parcels WHERE parcel_id = {}
+        """.format(parcel_id)
+        try:
+            cursor = self.db.cursor()
+            print("Successfully created cursor. Getting parcel {} ...".format(parcel_id))
+            cursor.execute(get_parcel)
+            parc = cursor.fetchone()
+            if not parc:
+                return False
+            else:
+                return parc
+        except (Exception, psycopg2.Error) as error:
+            print ("Could not get parcel {}... ".format(parcel_id), error)
+            return error

--- a/app/tests/test_parcel_views.py
+++ b/app/tests/test_parcel_views.py
@@ -10,7 +10,8 @@ class TestParcelView(BaseTestClass):
         """This will test POST /parcels"""
 
         res = self.client.post(
-            "api/v2/users/parcels", data=json.dumps(self.generic_parcel), content_type="application/json", headers=self.headers)
+            "api/v2/users/parcels", data=json.dumps(self.generic_parcel),
+            content_type="application/json", headers=self.headers)
 
         result = json.loads(res.data)
         self.assertEqual(res.status_code, 201)
@@ -31,3 +32,90 @@ class TestParcelView(BaseTestClass):
     def test_valid_weight(self):
         """Parcels must have valid weight"""
         pass
+
+    def test_admin_can_create_parcel(self):
+        """Admins should not be able to create parcels"""
+        pass
+
+    def test_user_change_destination(self):
+        """User should be able to change destination of parcels
+        that are pending"""
+
+        self.client.post("/api/v2/users/parcels", data=json.dumps(self.generic_parcel),
+                         content_type="application/json", headers=self.headers)
+
+        update_destination = {"destination": "Malibu"}
+
+        res = self.client.put("/api/v2/parcels/1/destination", data=json.dumps(
+            update_destination), content_type="application/json", headers=self.headers)
+        result = json.loads(res.data)
+        self.assertEqual(result["Success"],
+                         "Destination for parcel 1 succesfully changed")
+        self.assertEqual(res.status_code, 200)
+
+    def test_user_enters_numbers_as_destination(self):
+        """User should not be able to add numbers as destination"""
+
+        parcel = {"parcel_name": "Contracts",
+                  "recipient_name": "Irelia",
+                  "pickup_location": "Mount DOOM",
+                  "destination": "1234123452",
+                  "weight": "323"}
+
+        res = self.client.post("api/v2/users/parcels", data=json.dumps(parcel),
+                               content_type="application/json", headers=self.headers)
+        result = json.loads(res.data)
+        self.assertEqual(result["Error"], "Please enter valid destination")
+        self.assertEqual(res.status_code, 400)
+
+    def test_nonexistent_parcel_destination(self):
+        """User should not be able to change destination of parcels
+        that don't exist"""
+
+        des = {"destination": "Nairoberry"}
+        res = self.client.put("/api/v2/parcels/1/destination",
+                              data=json.dumps(des), content_type="application/json",
+                              headers=self.headers)
+        result = json.loads(res.data)
+        self.assertEqual(result["Error"], "Parcel not found")
+        self.assertEqual(res.status_code, 404)
+
+    def test_admin_change_destination(self):
+        """Admin should not be able to change the destination of parcels"""
+
+        self.client.post(
+            "api/v2/users/parcels", data=(json.dumps(self.generic_parcel)),
+            content_type="application/json", headers=self.headers)
+
+        des = {"destination": "Nairoberry"}
+
+        res = self.client.put("/api/v2/parcels/1/destination",
+                              data=json.dumps(des), content_type="application/json",
+                              headers=self.admin_header)
+        result = json.loads(res.data)
+        self.assertEqual(result["Forbidden"],
+                         "Admins cannot change destinaion of parcels")
+        self.assertEqual(res.status_code, 403)
+
+    def test_user_cannot_change_destination_of_parcel_they_did_not_create(self):
+        """Users should not be able to change destination of parcels that are
+        not theirs"""
+
+        self.client.post(
+            "api/v2/users/parcels", data=(json.dumps(self.generic_parcel)),
+            content_type="application/json", headers=self.headers)
+
+        self.client.post("/api/v2/auth/signup", data=json.dumps(self.generic_user),
+                         content_type="application/json")
+        log = self.client.post("/api/v2/auth/login", data=json.dumps(self.generic_user_details),
+                               content_type="application/json")
+        logs = json.loads(log.get_data(as_text=True))
+        log_token = logs["token"]
+        temp_headers = {"AUTHORIZATION": "Bearer " + log_token}
+        update_destination = {"destination": "Nairoberry"}
+        res = self.client.put("api/v2/parcels/1/destination", data=json.dumps(
+            update_destination), content_type="application/json", headers=temp_headers)
+        result = json.loads(res.data)
+        self.assertEqual(
+            result["Unauthorized"], "You can only update destination of your own parcels")
+        self.assertEqual(res.status_code, 401)


### PR DESCRIPTION
### What does this PR do?
Add feature allowing users to change destination of parcels they create so long as they are pending and the user that makes the request also made the parcel

### Brief description of task to be accomplished
Users should be able to change the destination of parcels, especially if the parcels are still pending. This is very convenient. This secured endpoint allows users to change the destination of all parcels they create that are still pending.

### How can this be manually tested?
Follow installation guidelines in the README page and then try accessing the endpoint for changing destination. Note that you must provide "destination" key and equivalent value in the JSON. you must also provide access token and the parcel you want to change must be available and pending.

### PT stories
#162030635
