### PR TITLE
[#162030643] users can get all their parcels 

### DIFF
--- a/app/api/v2/__init__.py
+++ b/app/api/v2/__init__.py
@@ -2,7 +2,8 @@ from flask import Blueprint
 from flask_restful import Api
 
 from app.api.v2.views.user_views import SignupView, LoginView
-from app.api.v2.views.parcel_views import ParcelCreate, ParcelDestination
+from app.api.v2.views.parcel_views import (
+    ParcelCreate, ParcelDestination, ParcelView)
 
 version2 = Blueprint("v2", __name__, url_prefix="/api/v2")
 api2 = Api(version2, catch_all_404s=True)
@@ -12,3 +13,4 @@ api2.add_resource(SignupView, "/auth/signup")
 api2.add_resource(LoginView, "/auth/login")
 api2.add_resource(ParcelCreate, "/users/parcels")
 api2.add_resource(ParcelDestination, "/parcels/<int:parcel_id>/destination")
+api2.add_resource(ParcelView, "/parcels")

--- a/app/api/v2/views/parcel_views.py
+++ b/app/api/v2/views/parcel_views.py
@@ -94,3 +94,20 @@ class ParcelDestination(Resource, Parcels):
             return {"Unauthorized": "You can only update destination of your own parcels"}, 401
         else:
             return {"Something went wrong": update_destination}
+
+
+class ParcelView(Resource, Parcels):
+    """This class has methods for returning all parcels stored in our database"""
+
+    def __init__(self):
+        self.parcel = Parcels()
+
+    def get(self):
+        """This method handles requests to get all parcels"""
+
+        parcels = self.parcel.get_all_parcels()
+
+        if parcels == 404:
+            return {"Error": "You have no parcels made"}, 404
+        else:
+            return {"Here are the parcels": parcels}, 200


### PR DESCRIPTION
### What does this PR do?
add functionality allowing users to get all parcels they have created. Admins get all parcels created by every user.

### Description of task to be accomplished
Users should be able to get all the parcels they have created so that they can keep track of them. Admins will need to change information about different parcels so it's important they are able to see all the parcels in the database

### How can this be manually tested?
Follow installation instructions in the README file and then create a few parcel orders with different users. You should notice that only admin tokens can get all parcel orders while each user token only gets information about the deliveries created by the owner of the token.

### PT stories
#162030643