### PR TITLE
[#162031034] admin can change status of orders

### DIFF
--- a/app/api/v2/__init__.py
+++ b/app/api/v2/__init__.py
@@ -3,7 +3,7 @@ from flask_restful import Api
 
 from app.api.v2.views.user_views import SignupView, LoginView
 from app.api.v2.views.parcel_views import (
-    ParcelCreate, ParcelDestination, ParcelView)
+    ParcelCreate, ParcelDestination, ParcelView, ParcelStatus)
 
 version2 = Blueprint("v2", __name__, url_prefix="/api/v2")
 api2 = Api(version2, catch_all_404s=True)
@@ -14,3 +14,4 @@ api2.add_resource(LoginView, "/auth/login")
 api2.add_resource(ParcelCreate, "/users/parcels")
 api2.add_resource(ParcelDestination, "/parcels/<int:parcel_id>/destination")
 api2.add_resource(ParcelView, "/parcels")
+api2.add_resource(ParcelStatus, "/parcels/<int:parcel_id>/status")

--- a/app/api/v2/models/parcel_models.py
+++ b/app/api/v2/models/parcel_models.py
@@ -159,3 +159,29 @@ class Parcels():
         except (Exception, psycopg2.Error) as error:
             print("Could not get any parcels from database: ", error)
             return error
+
+    def change_status(self, parcel_id, status):
+        """This method handles requests to change the status of an order"""
+
+        parcel = self.get_parcel_by_id(parcel_id)
+
+        if not parcel:
+            return 404
+        elif parcel[9] is "delivered" or parcel[9] == "cancelled":
+            return 400
+        else:
+            change_status = """
+            UPDATE parcels SET status = '{}' WHERE parcel_id = {}""".format(status, parcel_id)
+        try:
+            cursor = self.db.cursor()
+            print("Successfully created cursor. Changing the status of parcel number {} ...".format(
+                parcel_id))
+            cursor.execute(change_status)
+            self.db.commit()
+            count = cursor.rowcount
+            print("Successfully changed the status parcel {}. {} rows affected.".format(
+                parcel_id, count))
+            return 204
+        except (Exception, psycopg2.Error) as error:
+            print("Could not change the status of the order: ", error)
+            return error, 400

--- a/app/api/v2/views/parcel_views.py
+++ b/app/api/v2/views/parcel_views.py
@@ -111,3 +111,38 @@ class ParcelView(Resource, Parcels):
             return {"Error": "You have no parcels made"}, 404
         else:
             return {"Here are the parcels": parcels}, 200
+
+
+class ParcelStatus(Resource, Parcels):
+    """This class contains methods that handle requests to change the status of a
+    parcel delivery order"""
+
+    def __init__(self):
+        self.parcel = Parcels()
+        self.inspect_status = R()
+        self.inspect_status.add_argument(
+            "status", help="Please enter the status", required=True)
+
+    @jwt_required
+    def put(self, parcel_id):
+        """This method handles requests to change the status
+        of a parcel delivery order"""
+
+        user_info = get_jwt_identity()
+        if user_info["is_admin"] is False:
+            return {"Forbidden": "Only admins can change status of parcels"}, 403
+
+        status_info = self.inspect_status.parse_args()
+        status_received = status_info.get("status")
+        viable_status = ['transit', 'delivered']
+
+        if status_received not in viable_status:
+            return {"Error": "Status can only be changed to 'transit' or 'delivered'."}, 400
+        else:
+            status = status_received
+            change_status = self.parcel.change_status(parcel_id, status)
+
+        if change_status == 204:
+            return {"Success": "The status for parcel number {} was successfully changed".format(parcel_id)}, 200
+        elif change_status == 404:
+            return {"Error": "Parcel not found."}, 404


### PR DESCRIPTION
### What does this PR do?
add functionality allowing admins to change the status of orders

### Description of task to be accomplished
the admin should be able to change the status of the orders so that users are duly notified. This protected endpoint is only accessible to admins and allows them to change the status of orders

### How can this be manually tested?
Follow installation instructions on the README file then create a few parcels with different users. You can then log in the admin and change the status of parcels, but once they are delivered or cancelled, the status may not be changed again

### PT stories
#162031034