### PR TITLE
[#162031064] admin can update current location 

### DIFF
--- a/app/api/v2/__init__.py
+++ b/app/api/v2/__init__.py
@@ -3,7 +3,7 @@ from flask_restful import Api
 
 from app.api.v2.views.user_views import SignupView, LoginView
 from app.api.v2.views.parcel_views import (
-    ParcelCreate, ParcelDestination, ParcelView, ParcelStatus)
+    ParcelCreate, ParcelDestination, ParcelView, ParcelStatus, ParcelLocation)
 
 version2 = Blueprint("v2", __name__, url_prefix="/api/v2")
 api2 = Api(version2, catch_all_404s=True)
@@ -13,5 +13,6 @@ api2.add_resource(SignupView, "/auth/signup")
 api2.add_resource(LoginView, "/auth/login")
 api2.add_resource(ParcelCreate, "/users/parcels")
 api2.add_resource(ParcelDestination, "/parcels/<int:parcel_id>/destination")
+api2.add_resource(ParcelLocation, "/parcels/<int:parcel_id>/presentLocation")
 api2.add_resource(ParcelView, "/parcels")
 api2.add_resource(ParcelStatus, "/parcels/<int:parcel_id>/status")

--- a/app/api/v2/models/parcel_models.py
+++ b/app/api/v2/models/parcel_models.py
@@ -185,3 +185,29 @@ class Parcels():
         except (Exception, psycopg2.Error) as error:
             print("Could not change the status of the order: ", error)
             return error, 400
+
+    def change_location(self, parcel_id, current_location):
+        """This method handles requests to change the location of a delivery in transit"""
+
+        parcel = self.get_parcel_by_id(parcel_id)
+
+        if not parcel:
+            return 404
+        elif parcel[9] != "transit":
+            return 400
+        else:
+            update_location = """
+            UPDATE parcels SET current_location = '{}'
+            WHERE parcel_id = {}""".format(current_location, parcel_id)
+
+        try:
+            cursor = self.db.cursor()
+            print("Successfully created cursor. Updating current location for parcel \
+                number {} ...".format(parcel_id))
+            cursor.execute(update_location)
+            self.db.commit()
+            print("Location successfully changed")
+            return 204
+        except (Exception, psycopg2.Error) as error:
+            print("Could not change destinaion of parcel: ", error)
+            return error

--- a/app/api/v2/views/parcel_views.py
+++ b/app/api/v2/views/parcel_views.py
@@ -146,3 +146,37 @@ class ParcelStatus(Resource, Parcels):
             return {"Success": "The status for parcel number {} was successfully changed".format(parcel_id)}, 200
         elif change_status == 404:
             return {"Error": "Parcel not found."}, 404
+
+
+class ParcelLocation(Resource, Parcels):
+    """When an admin wants to change the location of a parcel delivery, the
+    request is handled by the put method in this class"""
+
+    def __init__(self):
+        self.parcel = Parcels()
+        self.inspect_location = R()
+        self.inspect_location.add_argument(
+            "current_location", help="Please enter location", required=True)
+
+    @jwt_required
+    def put(self, parcel_id):
+
+        user_data = get_jwt_identity()
+        if user_data["is_admin"] is False:
+            return {"Forbidden": "Only admins can update the present location of a parcel."}, 403
+
+        location_updated = self.inspect_location.parse_args()
+        current_location = location_updated["current_location"]
+
+        if not helpers.validate_string(current_location):
+            return {"Error": "Please enter a valid location"}, 400
+
+        update_location = self.parcel.change_location(
+            parcel_id, current_location)
+
+        if update_location == 204:
+            return {"Success": "Successfully updated current location"}, 200
+        elif update_location == 404:
+            return {"Error": "Parcel not found"}, 404
+        elif update_location == 400:
+            return {"Error": "You can only change location of parcels in transit"}, 400


### PR DESCRIPTION
### What does this PR do?
add functionality allowing admins to change current location of parcels in transit

### Description of tasks to be accomplished
Admins should be able to update the current location of parcel orders in transit so that users may keep track of them. This secured endpoint allows admins to do exactly that.

### How can this be manually tested?
Install the project by following instructions on the README file. After that you can access the endpoint for updating current location but you should note that only admins can access this endpoint, and all parcels must be in transit for their location to be updated.

### PT stories
#162031064