### PR TITLE
Ft user cancel orders 162162945

### DIFF
--- a/app/api/v2/__init__.py
+++ b/app/api/v2/__init__.py
@@ -3,7 +3,7 @@ from flask_restful import Api
 
 from app.api.v2.views.user_views import SignupView, LoginView
 from app.api.v2.views.parcel_views import (
-    ParcelCreate, ParcelDestination, ParcelView, ParcelStatus, ParcelLocation)
+    ParcelCreate, ParcelDestination, ParcelView, ParcelStatus, ParcelLocation, CancelParcel)
 
 version2 = Blueprint("v2", __name__, url_prefix="/api/v2")
 api2 = Api(version2, catch_all_404s=True)
@@ -16,3 +16,4 @@ api2.add_resource(ParcelDestination, "/parcels/<int:parcel_id>/destination")
 api2.add_resource(ParcelLocation, "/parcels/<int:parcel_id>/presentLocation")
 api2.add_resource(ParcelView, "/parcels")
 api2.add_resource(ParcelStatus, "/parcels/<int:parcel_id>/status")
+api2.add_resource(CancelParcel, "/parcels/<int:parcel_id>/cancel")

--- a/app/api/v2/views/parcel_views.py
+++ b/app/api/v2/views/parcel_views.py
@@ -180,3 +180,29 @@ class ParcelLocation(Resource, Parcels):
             return {"Error": "Parcel not found"}, 404
         elif update_location == 400:
             return {"Error": "You can only change location of parcels in transit"}, 400
+
+
+class CancelParcel(Resource, Parcels):
+    """This class contains methods that will handel requests for cancelling any orders"""
+
+    def __init__(self):
+        self.parcel = Parcels()
+
+    @jwt_required
+    def put(self, parcel_id):
+        """This method will handle requests to cancel any parcel in transit"""
+
+        user_info = get_jwt_identity()
+        if user_info["is_admin"] is True:
+            return {"Forbidden": "Admins cannot cancel parcels"}, 403
+
+        send_request = self.parcel.cancel_parcel(parcel_id)
+
+        if send_request == 404:
+            return {"Error": "Parcel not found"}, 404
+        elif send_request == 204:
+            return {"Success": "Successfully cancelled your parcel"}, 200
+        elif send_request == 401:
+            return {"Error": "You can only cancel parcels you created"}, 401
+        elif send_request == 400:
+            return {"Error": "You can only cancel parcels in transit"}, 400


### PR DESCRIPTION
### What does this PR do?
Users can now cancel orders if they are not delivered or cancelled

### Description of task to be completed
User should be able to cancel orders they created if they are not yet delivered or cancelled. This endpoint cannot be used by admins and users only get to cancel their own parcels

### How should this be manually tested?
Follow installation instructions then sign in a user and copy the access token. Use the token to create a parcel and cancel it. 

### PT stories
#162162945