### PR TITLE
[#162180474] bugfix - admin change status on correct parcels

### DIFF
--- a/app/api/v2/models/parcel_models.py
+++ b/app/api/v2/models/parcel_models.py
@@ -2,8 +2,6 @@ import psycopg2
 from db_config import init_db
 from flask_jwt_extended import jwt_required, get_jwt_identity
 
-from app.api.v2.models.user_models import Users
-
 
 class Parcels():
     """The methods defined in this class represent methods that users
@@ -160,12 +158,11 @@ class Parcels():
 
     def change_status(self, parcel_id, status):
         """This method handles requests to change the status of an order"""
-
         parcel = self.get_parcel_by_id(parcel_id)
 
         if not parcel:
             return 404
-        elif parcel[9] is "delivered" or parcel[9] == "cancelled":
+        elif parcel[9] == "delivered" or parcel[9] == "cancelled":
             return 400
         else:
             change_status = """

--- a/app/tests/__init__.py
+++ b/app/tests/__init__.py
@@ -14,8 +14,9 @@ class BaseTestClass(unittest.TestCase):
         self.client = self.app.test_client()
         self.app.testing = True
 
+        #set up, sign up and log in a default user
         self.default_user = {"first_name": "Default",
-                             "last_name": "Last Name",
+                             "last_name": "User",
                              "email": "default@user.com",
                              "password": "password",
                              "confirm_password": "password",
@@ -27,33 +28,40 @@ class BaseTestClass(unittest.TestCase):
         self.client.post("/api/v2/auth/signup",
                          data=json.dumps(self.default_user),
                          content_type="application/json")
+
         log = self.client.post("/api/v2/auth/login", data=json.dumps(
             self.default_user_login), content_type="application/json")
+
         user_data = json.loads(log.get_data(as_text=True))
+
+        #get default user token
         self.default_user_token = user_data["token"]
         self.headers = {"AUTHORIZATION": "Bearer " + self.default_user_token}
 
-        self.generic_user = {"first_name": "Test First",
-                             "last_name": "Test Second",
-                             "email": "testing@gmail.com",
-                             "password": "testing",
-                             "confirm_password": "testing",
+        #set up generic user information
+        self.generic_user = {"first_name": "Generic",
+                             "last_name": "User",
+                             "email": "generic@user.com",
+                             "password": "password",
+                             "confirm_password": "password",
                              "phone": "09323834134"}
-        self.generic_user_details = {"email": "testing@gmail.com",
-                                     "password": "testing"}
+        self.generic_user_details = {"email": "generic@user.com",
+                                     "password": "password"}
 
-        self.generic_parcel = {"parcel_name": "Contracts",
-                               "recipient_name": "Irelia",
-                               "pickup_location": "Mount DOOM",
-                               "destination": "Gondor",
-                               "weight": "323"
+        #set up generic parcel details
+        self.generic_parcel = {"parcel_name": "Generic Test Parcel",
+                               "recipient_name": "Generic Recipient",
+                               "pickup_location": "Generic Pickup",
+                               "destination": "Generic Destination",
+                               "weight": "420"
                                }
 
-        self.default_parcel = {"parcel_name": "Contracts",
-                               "recipient_name": "Irelia",
-                               "pickup_location": "Mount DOOM",
-                               "destination": "Gondor",
-                               "weight": "323"}
+        #set up default parcel details
+        self.default_parcel = {"parcel_name": "Default Test Parcel",
+                               "recipient_name": "Default Recipient",
+                               "pickup_location": "Default Location",
+                               "destination": "Default Destination",
+                               "weight": "420"}
 
         # we need to sign in the admin
         admin_details = {"email": "admin@admin.admin",
@@ -67,7 +75,7 @@ class BaseTestClass(unittest.TestCase):
         self.admin_header = {"AUTHORIZATION": "Bearer " + self.admin_token}
 
         # the default user creates a default parcel each time a test is run
-        self.client.post("/api/v2/parcels", data=json.dumps(self.default_parcel),
+        self.client.post("/api/v2/users/parcels", data=json.dumps(self.default_parcel),
                          content_type="application/json", headers=self.headers)
 
     def tearDown(self):

--- a/app/tests/test_parcel_views.py
+++ b/app/tests/test_parcel_views.py
@@ -19,19 +19,67 @@ class TestParcelView(BaseTestClass):
 
     def test_invalid_parcel_name(self):
         """Parcels must have valid names in order to be sent"""
-        pass
+        fake_parcel = {"parcel_name": "   ",
+                       "recipient_name": "Generic Recipient",
+                       "pickup_location": "Generic Pickup",
+                       "destination": "Generic Destination",
+                       "weight": "420"
+                       }
+        res = self.client.post("/api/v2/users/parcels",
+                               data=json.dumps(fake_parcel),
+                               content_type="application/json", headers=self.headers)
+        result = json.loads(res.data)
+        self.assertEqual(result["Error"], "Please enter valid parcel name")
+        self.assertEqual(res.status_code, 400)
 
     def test_invalid_pickup_location(self):
         """Parcels must have valid pickup location"""
-        pass
+        fake_parcel = {"parcel_name": "fake",
+                       "recipient_name": "Generic Recipient",
+                       "pickup_location": "     ",
+                       "destination": "Generic Destination",
+                       "weight": "420"
+                       }
+
+        res = self.client.post("/api/v2/users/parcels",
+                               data=json.dumps(fake_parcel),
+                               content_type="application/json", headers=self.headers)
+        result = json.loads(res.data)
+        self.assertEqual(result["Error"], "Please enter valid pickup location")
+        self.assertEqual(res.status_code, 400)
 
     def test_invalid_destination(self):
         """Parcels must have valid destination"""
-        pass
+        fake_parcel = {"parcel_name": "fake",
+                       "recipient_name": "Generic Recipient",
+                       "pickup_location": "Over here",
+                       "destination": "   ",
+                       "weight": "420"
+                       }
+
+        res = self.client.post("/api/v2/users/parcels",
+                               data=json.dumps(fake_parcel),
+                               content_type="application/json", headers=self.headers)
+        result = json.loads(res.data)
+        self.assertEqual(result["Error"], "Please enter valid destination")
+        self.assertEqual(res.status_code, 400)
 
     def test_valid_weight(self):
         """Parcels must have valid weight"""
-        pass
+        fake_parcel = {"parcel_name": "fake",
+                       "recipient_name": "Generic Recipient",
+                       "pickup_location": "Over here",
+                       "destination": "Over there",
+                       "weight": "so fake"
+                       }
+
+        res = self.client.post("/api/v2/users/parcels",
+                               data=json.dumps(fake_parcel),
+                               content_type="application/json", headers=self.headers)
+        result = json.loads(res.data)
+        self.assertEqual(
+            result["Error"], "Please enter postive weight in integers")
+        self.assertEqual(res.status_code, 400)
 
     def test_admin_can_create_parcel(self):
         """Admins should not be able to create parcels"""
@@ -78,7 +126,7 @@ class TestParcelView(BaseTestClass):
         that don't exist"""
 
         des = {"destination": "Nairoberry"}
-        res = self.client.put("/api/v2/parcels/1/destination",
+        res = self.client.put("/api/v2/parcels/5/destination",
                               data=json.dumps(des), content_type="application/json",
                               headers=self.headers)
         result = json.loads(res.data)
@@ -204,7 +252,7 @@ class TestParcelView(BaseTestClass):
         """Admin should only change status of parcels that exist"""
 
         status = {"status": "delivered"}
-        res = self.client.put("/api/v2/parcels/1/status", data=json.dumps(
+        res = self.client.put("/api/v2/parcels/5/status", data=json.dumps(
             status), content_type="application/json", headers=self.admin_header)
         result = json.loads(res.data)
         self.assertEqual(result["Error"],
@@ -214,7 +262,17 @@ class TestParcelView(BaseTestClass):
     def test_admin_change_status_of_delivered_parcels(self):
         """Admin should not be able to change status of parcels that have been cancelled
         or delivered"""
-        pass
+
+        status = {"status": "delivered"}
+        self.client.put("/api/v2/parcels/1/status", data=json.dumps(
+            status), content_type="application/json", headers=self.admin_header)
+        new_status = {"status": "transit"}
+        res = self.client.put("/api/v2/parcels/1/status", data=json.dumps(
+            new_status), content_type="application/json", headers=self.admin_header)
+        result = json.loads(res.data)
+        self.assertEqual(result["Error"],
+                         "Status cannot be changed for delivered or cancelled parcels")
+        self.assertEqual(res.status_code, 400)
 
     def test_user_can_change_location(self):
         """Users should not be able to change location of parcels"""
@@ -254,7 +312,7 @@ class TestParcelView(BaseTestClass):
         """Admin should not be able to change location of parcels that don't exist"""
 
         location = {"current_location": "Nairoberry"}
-        res = self.client.put("/api/v2/parcels/1/presentLocation", data=json.dumps(
+        res = self.client.put("/api/v2/parcels/5/presentLocation", data=json.dumps(
             location), content_type="application/json", headers=self.admin_header)
         result = json.loads(res.data)
 
@@ -347,7 +405,7 @@ class TestParcelView(BaseTestClass):
     def test_user_can_cancel_nonexistent_parcels(self):
         """User should not be able to cancel parcels that don't exist"""
 
-        res = self.client.put("/api/v2/parcels/1/cancel",
+        res = self.client.put("/api/v2/parcels/5/cancel",
                               headers=self.headers)
         result = json.loads(res.data)
 

--- a/app/tests/test_user_models.py
+++ b/app/tests/test_user_models.py
@@ -13,7 +13,7 @@ class TestUserModels(BaseTestClass):
             "/api/v2/auth/signup", data=json.dumps(self.generic_user), content_type="application/json")
         result = json.loads(res.data)
         self.assertEqual(
-            result["Success"], "Succesfully created account for testing@gmail.com")
+            result["Success"], "Succesfully created account for generic@user.com")
         self.assertEqual(res.status_code, 201)
 
     def test_duplicate_signup_attempt(self):
@@ -56,7 +56,7 @@ class TestUserModels(BaseTestClass):
             content_type="application/json")
         result = json.loads(res.data)
         self.assertEqual(result["Success"],
-                         "You are logged in as testing@gmail.com.")
+                         "You are logged in as generic@user.com.")
         self.assertEqual(res.status_code, 201)
 
     def test_wrong_password_login(self):


### PR DESCRIPTION
### What does this PR do?
forbids admins from changing status of parcels that have been delivered or cancelled

### Description of task to be accomplished
admins should not be able to change the status of parcels that have been delivered or cancelled. they will now receive 400 status code when they attempt to change the status of parcels that have been delivered or cancelled. The database records will also not be edited.

### How can this be manually tested?
Install the app by following instructions on the README page. After that sign up a user and create a parcel, then sign up an admin and change the status of the parcel you created to delivered. If you try to change the status of the same parcel, you get an error.

### PT stories
#162180474